### PR TITLE
Add Duke's Birthright + Bugfixes

### DIFF
--- a/content/players.xml
+++ b/content/players.xml
@@ -11,6 +11,5 @@
 		    extraportrait="duke_extraportrait.anm2"
         skinColor="5"
         costumeSuffix="duke"
-        birthright="Your court expands"
     />
 </players>

--- a/content/players.xml
+++ b/content/players.xml
@@ -11,5 +11,6 @@
 		    extraportrait="duke_extraportrait.anm2"
         skinColor="5"
         costumeSuffix="duke"
+        birthright="Your court expands"
     />
 </players>

--- a/duke.lua
+++ b/duke.lua
@@ -123,6 +123,7 @@ dukeMod:AddCallback(ModCallbacks.MC_POST_PEFFECT_UPDATE, function(_, p)
 		if DukeHelpers.GetTrueSoulHearts(p) < DukeHelpers.MAX_HEALTH then
 			p:AddSoulHearts(DukeHelpers.MAX_HEALTH)
 		end
+		DukeHelpers.KillAtMaxBrokenFlies(p)
 	end
 
 	if p:GetEternalHearts() > 0 then
@@ -224,8 +225,13 @@ dukeMod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, function(_, player, flags)
 				local f = DukeHelpers.GetEntityByInitSeed(fly.initSeed)
 				if f:GetData().layer == DukeHelpers.BIRTHRIGHT then
 					DukeHelpers.RemoveHeartFly(f)
+					DukeHelpers.SpawnAttackFly(f)
 				end
 			end
 		end
 	end
+end)
+
+dukeMod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, function(_, player, flags)
+
 end)

--- a/duke.lua
+++ b/duke.lua
@@ -13,7 +13,7 @@ dukeMod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, function(_, p, f)
 	end
 end, CacheFlag.CACHE_FLYING)
 
--- Adds flies when a heart is spawned
+-- Adds flies when a heart is collected
 dukeMod:AddCallback(ModCallbacks.MC_PRE_PICKUP_COLLISION, function(_, pickup, collider)
 	local p = collider:ToPlayer()
 
@@ -35,6 +35,9 @@ dukeMod:AddCallback(ModCallbacks.MC_PRE_PICKUP_COLLISION, function(_, pickup, co
 		end
 
 		local layer = DukeHelpers.OUTER
+		if p:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
+			layer = DukeHelpers.BIRTHRIGHT
+		end
 		local shouldSkip = false
 
 		for _ = 1, heartPrice.RED do
@@ -65,6 +68,9 @@ dukeMod:AddCallback(ModCallbacks.MC_PRE_PICKUP_COLLISION, function(_, pickup, co
 		end
 
 		layer = DukeHelpers.OUTER
+		if p:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
+			layer = DukeHelpers.BIRTHRIGHT
+		end
 
 		for _ = 1, heartPrice.SOUL do
 			local foundFly
@@ -207,4 +213,19 @@ dukeMod:AddCallback(ModCallbacks.MC_POST_UPDATE, function()
 			DukeHelpers.sfx:Play(SoundEffect.SOUND_ROCKET_BLAST_DEATH)
 		end
 	end)
+end)
+
+dukeMod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, function(_, player, flags)
+	if DukeHelpers.IsDuke(player) and player:GetData().duke and not player:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
+		local heartFlies = DukeHelpers.GetDukeData(player).heartFlies
+		if heartFlies then
+			for i = #heartFlies, 1, -1 do
+				local fly = heartFlies[i]
+				local f = DukeHelpers.GetEntityByInitSeed(fly.initSeed)
+				if f:GetData().layer == DukeHelpers.BIRTHRIGHT then
+					DukeHelpers.RemoveHeartFly(f)
+				end
+			end
+		end
+	end
 end)

--- a/duke.lua
+++ b/duke.lua
@@ -13,7 +13,7 @@ dukeMod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, function(_, p, f)
 	end
 end, CacheFlag.CACHE_FLYING)
 
--- Adds flies when a heart is collected
+-- Adds flies when a heart is spawned
 dukeMod:AddCallback(ModCallbacks.MC_PRE_PICKUP_COLLISION, function(_, pickup, collider)
 	local p = collider:ToPlayer()
 
@@ -35,9 +35,6 @@ dukeMod:AddCallback(ModCallbacks.MC_PRE_PICKUP_COLLISION, function(_, pickup, co
 		end
 
 		local layer = DukeHelpers.OUTER
-		if p:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
-			layer = DukeHelpers.BIRTHRIGHT
-		end
 		local shouldSkip = false
 
 		for _ = 1, heartPrice.RED do
@@ -68,9 +65,6 @@ dukeMod:AddCallback(ModCallbacks.MC_PRE_PICKUP_COLLISION, function(_, pickup, co
 		end
 
 		layer = DukeHelpers.OUTER
-		if p:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
-			layer = DukeHelpers.BIRTHRIGHT
-		end
 
 		for _ = 1, heartPrice.SOUL do
 			local foundFly
@@ -213,19 +207,4 @@ dukeMod:AddCallback(ModCallbacks.MC_POST_UPDATE, function()
 			DukeHelpers.sfx:Play(SoundEffect.SOUND_ROCKET_BLAST_DEATH)
 		end
 	end)
-end)
-
-dukeMod:AddCallback(ModCallbacks.MC_EVALUATE_CACHE, function(_, player, flags)
-	if DukeHelpers.IsDuke(player) and player:GetData().duke and not player:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
-		local heartFlies = DukeHelpers.GetDukeData(player).heartFlies
-		if heartFlies then
-			for i = #heartFlies, 1, -1 do
-				local fly = heartFlies[i]
-				local f = DukeHelpers.GetEntityByInitSeed(fly.initSeed)
-				if f:GetData().layer == DukeHelpers.BIRTHRIGHT then
-					DukeHelpers.RemoveHeartFly(f)
-				end
-			end
-		end
-	end
 end)

--- a/flies.lua
+++ b/flies.lua
@@ -37,6 +37,10 @@ dukeMod:AddCallback(ModCallbacks.MC_FAMILIAR_UPDATE, function(_, f)
 		f.OrbitDistance = Vector(60, 56)
 		f.OrbitSpeed = 0.01
 		f.CollisionDamage = 2
+	elseif data.layer == DukeHelpers.BIRTHRIGHT then
+		f.OrbitDistance = Vector(80, 76)
+		f.OrbitSpeed = 0.005
+		f.CollisionDamage = 1
 	end
 
 	local centerPos = f.Player.Position

--- a/flies.lua
+++ b/flies.lua
@@ -37,10 +37,6 @@ dukeMod:AddCallback(ModCallbacks.MC_FAMILIAR_UPDATE, function(_, f)
 		f.OrbitDistance = Vector(60, 56)
 		f.OrbitSpeed = 0.01
 		f.CollisionDamage = 2
-	elseif data.layer == DukeHelpers.BIRTHRIGHT then
-		f.OrbitDistance = Vector(80, 76)
-		f.OrbitSpeed = 0.005
-		f.CollisionDamage = 1
 	end
 
 	local centerPos = f.Player.Position

--- a/helpers/flies.lua
+++ b/helpers/flies.lua
@@ -260,3 +260,26 @@ function DukeHelpers.SpawnHeartFlyPoof(flySubType, pos, spawner)
 		poof.Color = color
 	end
 end
+
+function DukeHelpers.KillAtMaxBrokenFlies(player)
+	if DukeHelpers.IsDuke(player) and player:GetData().duke then
+		local heartFlies = DukeHelpers.GetDukeData(player).heartFlies
+		local brokenFlyCount = 0
+		if heartFlies then
+			for i = #heartFlies, 1, -1 do
+				local fly = heartFlies[i]
+				if fly.subType == DukeHelpers.Flies.FLY_BROKEN.heartFlySubType then
+					brokenFlyCount = brokenFlyCount + 1
+				end
+			end
+		end
+		local brokenFlyLimit = 24
+		if player:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
+			brokenFlyLimit = 42
+		end
+		if brokenFlyCount >= brokenFlyLimit then
+			player:Kill()
+		end
+		print(brokenFlyCount)
+	end
+end

--- a/helpers/flies.lua
+++ b/helpers/flies.lua
@@ -7,10 +7,12 @@ DukeHelpers.ATTACK_FLY_STARTING_SUBTYPE = 903
 DukeHelpers.INNER = 1
 DukeHelpers.MIDDLE = 2
 DukeHelpers.OUTER = 3
+DukeHelpers.BIRTHRIGHT = 4
 
 local INNER = DukeHelpers.INNER
 local MIDDLE = DukeHelpers.MIDDLE
 local OUTER = DukeHelpers.OUTER
+local BIRTHRIGHT = DukeHelpers.BIRTHRIGHT
 
 DukeHelpers.Flies = {}
 
@@ -42,6 +44,8 @@ function DukeHelpers.AddHeartFly(player, fly, specificAmount)
 			layer = MIDDLE
 		elseif DukeHelpers.CountByProperties(playerData.heartFlies, { layer = OUTER }) < 12 then
 			layer = OUTER
+		elseif player:ToPlayer():HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) and DukeHelpers.CountByProperties(playerData.heartFlies, { layer = BIRTHRIGHT }) < 18 then
+			layer = BIRTHRIGHT
 		else
 			local replacableFly = DukeHelpers.Find(playerData.heartFlies, function(f)
 				return f.subType ~= DukeHelpers.Flies.FLY_BROKEN.heartFlySubType
@@ -68,20 +72,6 @@ end
 
 function DukeHelpers.PositionHeartFly(fly, layer)
 	fly:ToFamiliar():AddToOrbit(DukeHelpers.ATTACK_FLY_STARTING_SUBTYPE + layer)
-end
-
-function DukeHelpers.RemoveHeartFly(heartFly)
-	local p = heartFly.SpawnerEntity
-	local playerData = DukeHelpers.GetDukeData(p)
-	if playerData.heartFlies then
-		for i, fly in pairs(playerData.heartFlies) do
-			if fly.initSeed == heartFly.InitSeed then
-				table.remove(playerData.heartFlies, i)
-				heartFly:Remove()
-				return
-			end
-		end
-	end
 end
 
 function DukeHelpers.GetFlyByHeartSubType(subType)

--- a/helpers/flies.lua
+++ b/helpers/flies.lua
@@ -7,12 +7,10 @@ DukeHelpers.ATTACK_FLY_STARTING_SUBTYPE = 903
 DukeHelpers.INNER = 1
 DukeHelpers.MIDDLE = 2
 DukeHelpers.OUTER = 3
-DukeHelpers.BIRTHRIGHT = 4
 
 local INNER = DukeHelpers.INNER
 local MIDDLE = DukeHelpers.MIDDLE
 local OUTER = DukeHelpers.OUTER
-local BIRTHRIGHT = DukeHelpers.BIRTHRIGHT
 
 DukeHelpers.Flies = {}
 
@@ -44,8 +42,6 @@ function DukeHelpers.AddHeartFly(player, fly, specificAmount)
 			layer = MIDDLE
 		elseif DukeHelpers.CountByProperties(playerData.heartFlies, { layer = OUTER }) < 12 then
 			layer = OUTER
-		elseif player:ToPlayer():HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) and DukeHelpers.CountByProperties(playerData.heartFlies, { layer = BIRTHRIGHT }) < 18 then
-			layer = BIRTHRIGHT
 		else
 			local replacableFly = DukeHelpers.Find(playerData.heartFlies, function(f)
 				return f.subType ~= DukeHelpers.Flies.FLY_BROKEN.heartFlySubType
@@ -72,6 +68,20 @@ end
 
 function DukeHelpers.PositionHeartFly(fly, layer)
 	fly:ToFamiliar():AddToOrbit(DukeHelpers.ATTACK_FLY_STARTING_SUBTYPE + layer)
+end
+
+function DukeHelpers.RemoveHeartFly(heartFly)
+	local p = heartFly.SpawnerEntity
+	local playerData = DukeHelpers.GetDukeData(p)
+	if playerData.heartFlies then
+		for i, fly in pairs(playerData.heartFlies) do
+			if fly.initSeed == heartFly.InitSeed then
+				table.remove(playerData.heartFlies, i)
+				heartFly:Remove()
+				return
+			end
+		end
+	end
 end
 
 function DukeHelpers.GetFlyByHeartSubType(subType)

--- a/items/dukesGullet.lua
+++ b/items/dukesGullet.lua
@@ -28,7 +28,13 @@ local function MC_USE_ITEM(_, type, rng, p, flags)
             effect.Color = Color(0, 0, 0, 1)
         else
             DukeHelpers.ForEachEntityInRoom(function(entity)
-                if DukeHelpers.IsFlyOfPlayer(entity, p) then
+                local outerLayer = DukeHelpers.OUTER
+                local outerLayerCount = 12
+                if p:HasCollectible(CollectibleType.COLLECTIBLE_BIRTHRIGHT) then
+                    outerLayer = DukeHelpers.BIRTHRIGHT
+                    outerLayerCount = 18
+                end
+                if DukeHelpers.IsFlyOfPlayer(entity, p) and DukeHelpers.CountByProperties(fliesData, { layer = outerLayer }) < outerLayerCount then
                     DukeHelpers.AddHeartFly(p, DukeHelpers.GetFlyByAttackSubType(entity.SubType), 1)
                     entity:Remove()
                 end


### PR DESCRIPTION
Duke's Birthright Effect - Allows Duke to have a fourth fly ring that holds 18 additional flies. For all purposes, such as devil deals, the fourth ring now counts as the outermost layer. If Birthright is lost, the fourth ring of flies turns into attack flies. Also makes it so Duke can have up to 42 Broken Heart Flies without dying, instead of 24.

Also fixes these funny bugs:
- If Duke has an amount of attack flies greater than his heart fly limit, using Duke's Gullet will turn as many attack flies as possible into orbitals, and keep the rest as Attack Flies.
- Having all Broken Heart Flies now kills Duke (24 normally, 42 with Birthright)